### PR TITLE
fixing build error(s) on x86_64 musl linux host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 PREFIX?=	/usr/local
 X11BASE?=	/usr/X11R6
 
-PKGLIBS=	x11 xft xpm gtk+-2.0
+PKGLIBS=	x11 xft xext xpm gtk+-2.0
 
 CC?=		cc
 CFLAGS+=	-O2 -Wall -Wunused \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ CFLAGS+=	-DUSE_GDK_PIXBUF
 BINDIR=		$(PREFIX)/bin
 MANDIR=		$(PREFIX)/man/man1
 
-PROGMAN_SRC=	atom.c \
+PROGMAN_SRC=	util.c \
+		atom.c \
 		client.c \
 		common.c \
 		events.c \

--- a/client.c
+++ b/client.c
@@ -33,6 +33,7 @@
 #endif
 #include "progman.h"
 #include "atom.h"
+#include "util.h"
 
 static void init_geom(client_t *, strut_t *);
 static void reparent(client_t *, strut_t *);

--- a/events.c
+++ b/events.c
@@ -20,6 +20,8 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#define INFTIM -1
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <poll.h>

--- a/progman.c
+++ b/progman.c
@@ -20,6 +20,8 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#define WAIT_ANY -1
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/util.c
+++ b/util.c
@@ -1,0 +1,4 @@
+/* the licence in util.h applies for this file as well */
+#include <stddef.h>
+#undef reallocarray
+void *reallocarray(void *, size_t, size_t);

--- a/util.h
+++ b/util.h
@@ -1,0 +1,38 @@
+/*	$OpenBSD: reallocarray.c,v 1.3 2015/09/13 08:31:47 guenther Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}


### PR DESCRIPTION
before i get butchered to death, i'd like to say that i'm not a programmer, i just went from error to error by reading manpages and searching things so apologies for the poor quality.

i don't know if anything non-obsd is supported but trying to build the commit `efb0f2` on an x86_64 musl linux host fails with these following errors and how i "fixed" them:

#### error 1
```sh
 2 progman: make -j1
x86_64-apathy-linux-musl-gcc -O2 -Wall -Wunused -Wunused -Wmissing-prototypes -Wstrict-prototypes `pkg-config --cflags x11 xft xpm gtk+-2.0 gdk-pixbuf-xlib-2.0` -DUSE_GDK_PIXBUF   -c -o events.o events.c
events.c: In function 'event_loop':
events.c:61:17: error: 'INFTIM' undeclared (first use in this function)
   61 |    poll(pfd, 2, INFTIM);
      |                 ^~~~~~
events.c:61:17: note: each undeclared identifier is reported only once for each function it appears in
make: *** [<builtin>: events.o] Error 1
```
adding `#define INFTIM -1` to `events.c` fixes that one.

------------
#### error 2
```sh
 0 progman: make -j1
x86_64-apathy-linux-musl-gcc -O2 -Wall -Wunused -Wunused -Wmissing-prototypes -Wstrict-prototypes `pkg-config --cflags x11 xft xpm gtk+-2.0 gdk-pixbuf-xlib-2.0` -DUSE_GDK_PIXBUF   -c -o progman.o progman.c
progman.c: In function 'setup_display':
progman.c:358:50: warning: pointer targets in passing argument 3 of 'set_string_atom' differ in signedness [-Wpointer-sign]
  358 |  set_string_atom(supporting_wm_win, net_wm_name, "progman", 7);
      |                                                  ^~~~~~~~~
      |                                                  |
      |                                                  char *
In file included from progman.h:32,
                 from progman.c:39:
atom.h:85:43: note: expected 'unsigned char *' but argument is of type 'char *'
   85 | extern void set_string_atom(Window, Atom, unsigned char *, unsigned long);
      |                                           ^~~~~~~~~~~~~~~
progman.c: In function 'sig_handler':
progman.c:375:25: error: 'WAIT_ANY' undeclared (first use in this function)
  375 |   while ((pid = waitpid(WAIT_ANY, &status, WNOHANG)) > 0 ||
      |                         ^~~~~~~~
progman.c:375:25: note: each undeclared identifier is reported only once for each function it appears in
make: *** [<builtin>: progman.o] Error 1
```
adding `#define WAIT_ANY -1` to `progman.c` fixes that one.

------------
#### error 3
```sh
x86_64-apathy-linux-musl-gcc -o progman atom.o client.o common.o events.o keyboard.o manage.o menu.o parser.o progman.o `pkg-config --libs x11 xft xpm gtk+-2.0`
/usr/bin/ld: progman.o: undefined reference to symbol 'XShapeQueryExtension'
/usr/bin/ld: /usr/lib/libXext.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:76: progman] Error 1
```
adding `xext` to the `PKGLIBS=` in the makefile fixes that.

------------
#### error 4
```sh
 0 progman: make
x86_64-apathy-linux-musl-gcc -o progman atom.o client.o common.o events.o keyboard.o manage.o menu.o parser.o progman.o `pkg-config --libs x11 xft xext xpm gtk+-2.0`
x86_64-apathy-linux-musl-gcc -o aemenu aemenu.o atom.o common.o menu.o parser.o `pkg-config --libs x11 xft xext xpm gtk+-2.0`
/usr/bin/ld: client.o: in function `redraw_icon':
client.c:(.text+0x191e): undefined reference to `reallocarray'
/usr/bin/ld: client.c:(.text+0x1ac6): undefined reference to `reallocarray'
/usr/bin/ld: manage.o: in function `restack_clients':
manage.c:(.text+0x1bf7): undefined reference to `reallocarray'
collect2: error: ld returned 1 exit status
make: *** [Makefile:76: progman] Error 1
make: *** Waiting for unfinished jobs....
```

i did some "research" for this and found that it's something obsd specific (i guess?) and saw that some other project added these two files from openbsd to build on musl:

`util.c`:
```c
#undef reallocarray
void *reallocarray(void *, size_t, size_t);
```

`util.h`:
```c
#include <sys/types.h>
#include <errno.h>
#include <stdint.h>
#include <stdlib.h>

#define MUL_NO_OVERFLOW ((size_t)1 << (sizeof(size_t) * 4))

void *
reallocarray(void *optr, size_t nmemb, size_t size)
{
        if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
            nmemb > 0 && SIZE_MAX / nmemb < size) {
                errno = ENOMEM;
                return NULL;
        }
        return realloc(optr, size * nmemb);
}
```

------------
#### error 5
then i added `util.c` to `PROGMAN_SRC=` in the makefile, which resulted in this following error when i ran `make`:
```sh
 2 progman: make -j1
x86_64-apathy-linux-musl-gcc -march=native -mtune=native -O2 -Wall -Wunused -Wunused -Wmissing-prototypes -Wstrict-prototypes `pkg-config --cflags x11 xft xext xpm gtk+-2.0`   -c -o util.o util.c
util.c:2:28: error: unknown type name 'size_t'
    2 | void *reallocarray(void *, size_t, size_t);
      |                            ^~~~~~
util.c:1:1: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
  +++ |+#include <stddef.h>
    1 | #undef reallocarray
util.c:2:36: error: unknown type name 'size_t'
    2 | void *reallocarray(void *, size_t, size_t);
      |                                    ^~~~~~
util.c:2:36: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
make: *** [<builtin>: util.o] Error 1
```
finally, after adding `#include <stddef.h>` to `util.h`, it got built successfully.